### PR TITLE
[Loveneesh] If city and district are empty use state edge to connect patients

### DIFF
--- a/util/filters/city.js
+++ b/util/filters/city.js
@@ -11,7 +11,7 @@ export const addCities = (graph, patients) => {
   for (let patientId in patients) {
     let city = patients[patientId].city
       ? patients[patientId].city
-      : patients[patientId].district
+      : (patients[patientId].district ? patients[patientId].district: patients[patientId].state )
     if (!states[hash(patients[patientId].state)]) {
       states[hash(patients[patientId].state)] = patients[patientId].state
       if (!stateCitiesMap[hash(patients[patientId].state)]) {
@@ -86,7 +86,7 @@ export const addCities = (graph, patients) => {
   for (let patientId in patients) {
     let city = patients[patientId].city
       ? patients[patientId].city
-      : patients[patientId].district
+      : (patients[patientId].district ? patients[patientId].district: patients[patientId].state )
     let edge = {
       from: hash(city),
       to: patients[patientId].patientId,


### PR DESCRIPTION
In reference with #101 

If the city and district fields are empty for a patient then use state to link the patient.