### PR TITLE
fix: Refactored styled components to prevent multiple creations in render method

### DIFF
--- a/components/FilterPanel/FilterContainer.js
+++ b/components/FilterPanel/FilterContainer.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledFilterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-evenly;
+    height: '20vh';
+    user-select: none;
+    background-color: ${props => (props.selected ? '#d6d6d6' : '#F2F2F2')};
+    transition: all 0.2s ease-out;
+    cursor: pointer;
+    &:hover {
+      background-color: #d7d7d7;
+    }
+  `
+const FilterContainer = (props) => <StyledFilterContainer {...props}>{props.children}</StyledFilterContainer>
+
+export default FilterContainer;
+

--- a/components/FilterPanel/FilterHeader.js
+++ b/components/FilterPanel/FilterHeader.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledFilterHeader = styled.div`
+    text-align: center;
+    text-transform: uppercase;
+    font-size: 14px;
+
+    @media screen and (max-width: 768px) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    }
+`
+
+const FilterHeader = (props) => <StyledFilterHeader {...props}>{props.children}</StyledFilterHeader>
+
+export default FilterHeader;
+

--- a/components/FilterPanel/FilterIcon.js
+++ b/components/FilterPanel/FilterIcon.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledFilterIcon = styled.img`
+    width: 40px;
+`
+const FilterIcon = (props) => <StyledFilterIcon {...props}>{props.children}</StyledFilterIcon>
+
+export default FilterIcon;

--- a/components/FilterPanel/FilterName.js
+++ b/components/FilterPanel/FilterName.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledFilterName = styled.div`
+    text-transform: uppercase;
+    font-size: 11px;
+`
+const FilterName = (props) => <StyledFilterName {...props}>{props.children}</StyledFilterName>
+
+export default FilterName;

--- a/components/FilterPanel/index.js
+++ b/components/FilterPanel/index.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import FilterHeader from './FilterHeader';
+import FilterContainer from './FilterContainer';
+import FilterName from './FilterName';
+import FilterIcon from './FilterIcon';
+
 import { connect } from 'react-redux'
 import _ from 'lodash'
 
@@ -63,29 +68,6 @@ const FilterMenuContainer = styled.div`
 `
 
 const FilterCategory = ({ filter, onClick, selected }) => {
-  const FilterContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-evenly;
-    height: '20vh';
-    user-select: none;
-    background-color: ${props => (props.selected ? '#d6d6d6' : '#F2F2F2')};
-    transition: all 0.2s ease-out;
-    cursor: pointer;
-    &:hover {
-      background-color: #d7d7d7;
-    }
-  `
-  const FilterName = styled.div`
-    text-transform: uppercase;
-    font-size: 11px;
-  `
-
-  const FilterIcon = styled.img`
-    width: 40px;
-  `
-
   return (
     <FilterContainer onClick={onClick} selected={selected}>
       <FilterIcon src={filter.icon} />
@@ -119,23 +101,13 @@ const FilterPanel = ({
     console.log(newGraph)
     updateGraph(newGraph)
   }
-  const FilterHeader = styled.div`
-    text-align: center;
-    text-transform: uppercase;
-    font-size: 14px;
-
-    @media screen and (max-width: 768px) {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-  `
   return (
     <HeaderContainer>
       <FilterHeader>Cluster Filter</FilterHeader>
       <FilterMenuContainer>
         {filters.map(filterItem => (
           <FilterCategory
+            key={filterItem.name}
             filter={filterItem}
             onClick={() => changeGraph(filterItem.name)}
             selected={filter === filterItem.name ? true : false}

--- a/components/SidePanel/CellContainer.js
+++ b/components/SidePanel/CellContainer.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledCellContainer = styled.div`
+    font-family: 'Lato', sans-serif;
+    background: #fff;
+    border-radius: 5px;
+    border: 1px solid #e7e7e7;
+    padding: 15px 20px;
+  `
+
+const CellContainer = (props) => <StyledCellContainer {...props}>{props.children}</StyledCellContainer>
+
+export default CellContainer;
+

--- a/components/SidePanel/Name.js
+++ b/components/SidePanel/Name.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const StyledName = styled.div`
+    font-weight: 600;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  `
+
+  const Name = (props) => <StyledName {...props}>{props.children}</StyledName>
+
+export default Name;

--- a/components/SidePanel/datagrid.js
+++ b/components/SidePanel/datagrid.js
@@ -2,6 +2,9 @@ import React from 'react'
 import styled from 'styled-components'
 import _ from 'lodash'
 
+import CellContainer from './CellContainer';
+import Name from './Name';
+
 const Container = styled.div`
   font-size: 16px;
   display: grid;
@@ -21,20 +24,6 @@ const A = styled.a`
 `
 
 function Cell({ name, children }) {
-  const CellContainer = styled.div`
-    font-family: 'Lato', sans-serif;
-    background: #fff;
-    border-radius: 5px;
-    border: 1px solid #e7e7e7;
-    padding: 15px 20px;
-  `
-
-  const Name = styled.div`
-    font-weight: 600;
-    text-transform: uppercase;
-    margin-bottom: 10px;
-  `
-
   return (
     <CellContainer>
       <Name>{name}</Name>
@@ -82,7 +71,7 @@ export default function DataGrid(patient) {
                   href={source}
                   target="_blank"
                   rel="noopener noreferer"
-                  key={i}
+                  key={`link_${i}`}
                 >
                   {_.truncate(source, {
                     length: 40,


### PR DESCRIPTION
- Fix warnings related to creation of styled components in render method
- Created separate component files and wrapped the styled components in them
- src: https://github.com/styled-components/styled-components/issues/3015#issuecomment-585346714
- Warning content  : 
```
The component X with the id of Y has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component 
```
- Fix unique `key` related warning for filters
